### PR TITLE
feat: add Gmail readonly option for dry runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,8 @@ class FrontToGmailMigrator {
     this.logger.info('Initializing Gmail client...');
     this.gmailClient = await GmailClient.create(
       this.config.google.credentialsPath,
-      this.config.google.tokenPath
+      this.config.google.tokenPath,
+      this.config.migration.dryRun
     );
     this.logger.info('Gmail client initialized successfully');
   }


### PR DESCRIPTION
## Summary
- allow GmailClient to authenticate with readonly scope
- thread migrator passes dryRun flag to Gmail client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c704acf600832e9dc4adcc88751c08