### PR TITLE
Default to dry-run unless DRY_RUN=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GOOGLE_TOKEN_PATH=./token.json
 
 # Migration Settings
 BATCH_SIZE=10              # Process 10 conversations at a time
-DRY_RUN=true               # Set to false to make changes
+DRY_RUN=true               # Set to false to make changes (omit to stay in dry run mode)
 LOG_LEVEL=info             # error, warn, info, debug
 SKIP_ARCHIVED=false        # true: skip archived Front conversations
 FRONT_INBOX_ID=            # Optional: migrate only a specific Front inbox
@@ -97,7 +97,7 @@ This will:
 
 ### Actual Migration
 
-When satisfied with the dry run:
+When satisfied with the dry run (the tool defaults to dry run mode if `DRY_RUN` is omitted):
 
 1. Set `DRY_RUN=false` in `.env`
 2. Run the migration:

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ export function loadConfig(): Config {
     },
     migration: {
       batchSize: parseInt(process.env.BATCH_SIZE || '10', 10),
-      dryRun: process.env.DRY_RUN === 'true',
+      dryRun: process.env.DRY_RUN !== 'false',
       logLevel: getLogLevel(process.env.LOG_LEVEL),
       skipArchived: process.env.SKIP_ARCHIVED === 'true',
       inboxId: process.env.FRONT_INBOX_ID,


### PR DESCRIPTION
## Summary
- default to dry-run mode unless `DRY_RUN` is explicitly set to `false`
- document how omitting `DRY_RUN` keeps migration in dry-run mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c704a87e2c832e814d6cd11200d67b