### PR TITLE
Handle DRY_RUN flag case-insensitively

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ export function loadConfig(): Config {
     },
     migration: {
       batchSize: parseInt(process.env.BATCH_SIZE || '10', 10),
-      dryRun: process.env.DRY_RUN !== 'false',
+      dryRun: (process.env.DRY_RUN || '').toLowerCase() !== 'false',
       logLevel: getLogLevel(process.env.LOG_LEVEL),
       skipArchived: process.env.SKIP_ARCHIVED === 'true',
       inboxId: process.env.FRONT_INBOX_ID,


### PR DESCRIPTION
## Summary
- Normalize DRY_RUN environment variable to lowercase before comparison so only an explicit 'false' disables dry run.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node -e "function evalDRY_RUN(val){process.env.DRY_RUN=val; const dryRun=(process.env.DRY_RUN||'').toLowerCase() !== 'false'; console.log(val, '->', dryRun);} evalDRY_RUN('true'); evalDRY_RUN('false'); delete process.env.DRY_RUN; evalDRY_RUN(process.env.DRY_RUN);"`


------
https://chatgpt.com/codex/tasks/task_b_68c7088c4624832e85a9eb3a8ffb844b