### PR TITLE
Clarify keychain-based Gmail auth and remove unused config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install
    - Click "Create Credentials" > "OAuth client ID"
    - Choose "Desktop app"
    - Download the credentials JSON file
-5. Save the file as `credentials.json` in the project root
+5. Keep the file handy; you'll paste its contents when running the tool for the first time
 
 ### 4) Configure environment
 
@@ -64,10 +64,6 @@ cp .env.example .env
 # Front API Configuration
 FRONT_API_KEY=your_front_api_key_here
 FRONT_API_BASE_URL=https://api2.frontapp.com
-
-# Gmail API Configuration
-GOOGLE_CREDENTIALS_PATH=./credentials.json
-GOOGLE_TOKEN_PATH=./token.json
 
 # Migration Settings
 BATCH_SIZE=10              # Process 10 conversations at a time
@@ -88,7 +84,7 @@ npm run migrate
 ```
 
 This will:
-1. Authenticate with Gmail (first run creates `token.json`)
+1. Authenticate with Gmail (first run prompts for credentials and saves the token to your system keychain)
 2. Fetch conversations from Front
 3. Show what labels would be created (without creating them)
 4. Show what messages would be updated
@@ -156,7 +152,7 @@ You can filter this file to audit changes or spot-check ambiguous/skipped items.
 - Batch processing with short delays
 
 ### Authentication Issues
-1. Delete `token.json`
+1. Remove the stored Gmail token from your system keychain
 2. Run the tool again
 3. Follow the browser prompts to re-authenticate
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import * as dotenv from 'dotenv';
-import * as path from 'path';
 import { LogLevel } from './utils/logger_ascii';
 
 dotenv.config();
@@ -8,10 +7,6 @@ export interface Config {
   front: {
     apiKey: string;
     baseUrl: string;
-  };
-  google: {
-    credentialsPath: string;
-    tokenPath: string;
   };
   migration: {
     batchSize: number;
@@ -38,10 +33,6 @@ export function loadConfig(): Config {
       apiKey: process.env.FRONT_API_KEY || '',
       baseUrl: process.env.FRONT_API_BASE_URL || 'https://api2.frontapp.com',
     },
-    google: {
-      credentialsPath: process.env.GOOGLE_CREDENTIALS_PATH || './credentials.json',
-      tokenPath: process.env.GOOGLE_TOKEN_PATH || './token.json',
-    },
     migration: {
       batchSize: parseInt(process.env.BATCH_SIZE || '10', 10),
       dryRun: (process.env.DRY_RUN || '').toLowerCase() !== 'false',
@@ -54,14 +45,6 @@ export function loadConfig(): Config {
   // Validate required config
   if (!config.front.apiKey) {
     throw new Error('FRONT_API_KEY is required. Please set it in your .env file.');
-  }
-
-  // Make paths absolute
-  if (!path.isAbsolute(config.google.credentialsPath)) {
-    config.google.credentialsPath = path.resolve(process.cwd(), config.google.credentialsPath);
-  }
-  if (!path.isAbsolute(config.google.tokenPath)) {
-    config.google.tokenPath = path.resolve(process.cwd(), config.google.tokenPath);
   }
 
   return config;


### PR DESCRIPTION
## Summary
- drop unused Google credential path configuration
- document keychain-based Gmail setup and remove credential path env vars

## Testing
- `npm run build` *(fails: Cannot find module 'keytar' or its type declarations)*
- `npm install keytar@7.9.0` *(fails: 403 Forbidden - GET https://registry.npmjs.org/keytar)*

------
https://chatgpt.com/codex/tasks/task_b_68c70ccef00c832ebb8f31bc773fbd8a