### PR TITLE
chore: add electron wrapper

### DIFF
--- a/electron/index.html
+++ b/electron/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Front to Gmail Migration</title>
+</head>
+<body>
+  <h1>Front to Gmail Migration</h1>
+  <button id="run">Run Migration</button>
+  <pre id="output"></pre>
+  <script>
+    const btn = document.getElementById('run');
+    const output = document.getElementById('output');
+    btn.addEventListener('click', async () => {
+      output.textContent = 'Running...';
+      try {
+        const result = await window.electronAPI.runMigration();
+        output.textContent = result;
+      } catch (err) {
+        output.textContent = err;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,41 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(createWindow);
+
+ipcMain.handle('run-migration', () => {
+  return new Promise((resolve, reject) => {
+    const script = path.join(__dirname, '..', 'dist', 'index.js');
+    const child = spawn(process.execPath, [script], { cwd: path.join(__dirname, '..') });
+
+    let output = '';
+    child.stdout.on('data', data => { output += data.toString(); });
+    child.stderr.on('data', data => { output += data.toString(); });
+    child.on('close', code => {
+      if (code === 0) {
+        resolve(output);
+      } else {
+        reject(output);
+      }
+    });
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  runMigration: () => ipcRenderer.invoke('run-migration')
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
-    "migrate": "tsx src/index.ts"
+    "migrate": "tsx src/index.ts",
+    "electron": "npm run build && npx electron electron/main.js"
   },
   "keywords": ["front", "gmail", "migration", "email"],
   "author": "",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@types/node": "^22.10.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "electron": "^30.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add minimal Electron app that runs existing migration script via renderer button
- wire up preload bridge for renderer invocation
- expose npm script to launch the Electron shell

## Testing
- `npm install --save-dev electron@30` *(fails: 403 Forbidden - GET https://registry.npmjs.org/electron)*
- `npm run build` *(fails: Cannot find module 'keytar' or its corresponding type declarations)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c70ca904c8832ebb57d3347b224ca3