### PR TITLE
chore: prune dependencies before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "build": "tsc",
     "electron": "npm run build && npx electron electron/main.js",
-    "pack": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder",
-    "dist:mac": "npm run build && electron-builder --mac",
-    "dist:win": "npm run build && electron-builder --win",
-    "dist:linux": "npm run build && electron-builder --linux"
+    "pack": "npm run build && npm prune --production && npx electron-builder --dir",
+    "dist": "npm run build && npm prune --production && npx electron-builder",
+    "dist:mac": "npm run build && npm prune --production && npx electron-builder --mac",
+    "dist:win": "npm run build && npm prune --production && npx electron-builder --win",
+    "dist:linux": "npm run build && npm prune --production && npx electron-builder --linux"
   },
   "keywords": ["front", "gmail", "migration", "email"],
   "author": "",
@@ -37,8 +37,7 @@
     "files": [
       "dist/**",
       "electron/**",
-      "package.json",
-      "node_modules/**"
+      "package.json"
     ],
     "directories": {
       "buildResources": "electron"


### PR DESCRIPTION
## Summary
- exclude `node_modules` from Electron build files
- prune dev deps before running `electron-builder`

## Testing
- `npm run build`
- `npm prune --production`
- `npx electron-builder --mac` *(fails: 403 Forbidden when fetching electron-builder)*

------
https://chatgpt.com/codex/tasks/task_b_68c77c15a8e0832e805243efd90a9be7